### PR TITLE
Remove the needs for multiplexing in logs

### DIFF
--- a/src/plugins/logs.c
+++ b/src/plugins/logs.c
@@ -1,7 +1,11 @@
 #include <stdlib.h>
 #include <uv.h>
 #include <forza.h>
+#include <saneopt.h>
 #include "logs.h"
+
+static char* user;
+static char* name;
 
 void logs__on_stdio(char* data, forza__stdio_type_t type) {
   forza_metric_t* metric;
@@ -11,6 +15,8 @@ void logs__on_stdio(char* data, forza__stdio_type_t type) {
   metric->metric = 1.0;
   metric->description = data;
   metric->service = (type == STDIO_STDOUT) ? "logs/stdout" : "logs/stderr";
+  metric->meta->app->user = user;
+  metric->meta->app->name = name;
 
   forza_send(metric);
 
@@ -28,6 +34,9 @@ void logs__on_stderr(char* data) {
 int logs_init(forza_plugin_t* plugin) {
   plugin->stdout_data_cb = logs__on_stdout;
   plugin->stderr_data_cb = logs__on_stderr;
+
+  user = saneopt_get(plugin->saneopt, "app-user");
+  name = saneopt_get(plugin->saneopt, "app-name");
 
   return 0;
 }


### PR DESCRIPTION
This removes the need for multiplexing in `logs/*` events which will **ensure that logs are never served for the wrong user/app combo**

We accomplish this by sending `meta.app.user` and `meta.app.name` in `logs` messages.

cc/ @mmalecki 
