### PR TITLE
Cacheless metrics

### DIFF
--- a/src/plugins/mem.c
+++ b/src/plugins/mem.c
@@ -1,6 +1,9 @@
 #include <uv.h>
 #include <forza.h>
+#include <saneopt.h>
 
+static char* user;
+static char* name;
 static uv_timer_t mem_timer;
 
 void mem__send_usage(uv_timer_t *timer, int status) {
@@ -16,7 +19,11 @@ void mem__send_usage(uv_timer_t *timer, int status) {
   forza_metric_t* metric = forza_new_metric();
   metric->service = "health/machine/memory";
   metric->metric = mempct;
+  metric->meta->app->user = user;
+  metric->meta->app->name = name;
+
   forza_send(metric);
+
   forza_free_metric(metric);
 }
 
@@ -29,6 +36,9 @@ int mem_init(forza_plugin_t* plugin) {
 
   uv_timer_init(uv_default_loop(), &mem_timer);
   uv_timer_start(&mem_timer, mem__send_usage, 0, 5000);
+
+  user = saneopt_get(plugin->saneopt, "app-user");
+  name = saneopt_get(plugin->saneopt, "app-name");
 
   return 0;
 }

--- a/src/plugins/uptime.c
+++ b/src/plugins/uptime.c
@@ -1,7 +1,10 @@
 #include <time.h>
 #include <uv.h>
 #include <forza.h>
+#include <saneopt.h>
 
+static char* user;
+static char* name;
 static uv_timer_t uptime_timer;
 time_t start_time;
 
@@ -11,6 +14,9 @@ void uptime__send_uptime(uv_timer_t *timer, int status) {
 
   metric->service = "health/process/uptime";
   metric->metric = (double) (now - start_time);
+  metric->meta->app->user = user;
+  metric->meta->app->name = name;
+
   forza_send(metric);
 
   forza_free_metric(metric);
@@ -34,6 +40,9 @@ int uptime_init(forza_plugin_t* plugin) {
 
   uv_timer_init(uv_default_loop(), &uptime_timer);
   uv_timer_start(&uptime_timer, uptime__send_uptime, 0, 5000);
+
+  user = saneopt_get(plugin->saneopt, "app-user");
+  name = saneopt_get(plugin->saneopt, "app-name");
 
   return 0;
 }


### PR DESCRIPTION
Add username/appname to any metrics that we want to show to calculate on a per app basis. Removes the need for a cache lookup which is ideal. This would fix #24 as these 3 are the only metrics that seem directly useful for a user.

@mmalecki make sure i didn't mess anything up but it should be good.
