### PR TITLE
[fix] Use the new `saneopt_has` for -v/--version

### DIFF
--- a/src/forza.c
+++ b/src/forza.c
@@ -200,12 +200,6 @@ int main(int argc, char *argv[]) {
 
 #ifdef FORZA_VERSION_HASH
   printf("forza %s\n", FORZA_VERSION_HASH);
-  // saneopt doesn't allow options without input
-  for (v = 0; v < argc; v++) {
-    if (strcmp(argv[v], "-v") == 0 || strcmp(argv[v], "--version") == 0) {
-      return 0;
-    }
-  }
 #else
   printf("forza\n");
 #endif
@@ -214,6 +208,11 @@ int main(int argc, char *argv[]) {
 
   saneopt_alias(opt, "host", "h");
   saneopt_alias(opt, "port", "p");
+  saneopt_alias(opt, "version", "v");
+
+  if (saneopt_has(opt, "version")) {
+    return 0;
+  }
 
   host = saneopt_get(opt, "host");
   port_str = saneopt_get(opt, "port");


### PR DESCRIPTION
This pull request is not ready yet. It depends on `saneopt_has`, which is not pulled into `saneopt` yet.

Will hopefully be getting `saneopt_has` into the master of `saneopt` very soon.
